### PR TITLE
bump version for next release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CyclicArrays"
 uuid = "6023044f-b3ef-4c22-8399-3ec90a0c9b75"
 authors = ["udistr <udistr@gmail.com>"]
-version = "0.3.2"
+version = "0.3.3"
 
 [compat]
 julia = "1"


### PR DESCRIPTION
Hi @udistr 

There are been a few changes since the lastest tag (on June 13; `v0.3.1`) and the latest "proper" pkg release (on May 24; `v0.2.0`), so maybe it's a good time for new release. ok?

One thing about releases for Julia packages : maybe avoid doing tags / releases directly via GitHub -- i.e. use the [registrator & tagbot](https://github.com/JuliaRegistries/Registrator.jl) instead. 

Otherwise you end up skipping version numbers, which typically adds 3 days of wait time [see auto-merging rules](https://github.com/JuliaRegistries/RegistryCI.jl#automatic-merging-guidelines) as I expect to happen this time.

All you should need to do after merging this PR is to add a new `@JuliaRegistrator register` comment at the bottom of #7 and **wait** until the new release appears in your GitHub repo 

(the bot itself should end up doing the github release but it may take a little while, 1h maybe, after the merge of e.g. https://github.com/JuliaRegistries/General/pull/16267) 